### PR TITLE
Move the main entrypoint to __main__.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setuptools.setup(
     description="Yet Another Ambari Shell",
     url="https://github.com/dmtucker/yaas",
     packages=['yaas'],
-    entry_points={ 'console_scripts': [ "yaas = yaas.cmd:main" ] }
+    entry_points={ 'console_scripts': [ "yaas = yaas.__main__:main" ] }
     )
 

--- a/yaas/__main__.py
+++ b/yaas/__main__.py
@@ -66,3 +66,6 @@ def main():
 
     commands[args.command](subparsers.choices[args.command], extra)
 
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This allows us to do `python -m yaas` which I find particularly useful for developing (because we don't need to `python setup.py install`).
