### PR TITLE
Implement host list with decorators.

### DIFF
--- a/yaas/__main__.py
+++ b/yaas/__main__.py
@@ -60,7 +60,7 @@ def main():
         subparsers.add_parser(name, help=inspect.getdoc(fn))
 
     args, extra = parser.parse_known_args(sys.argv[1:])
-    config.args = args
+    config.command = args
 
     if args.command != 'version' and config.server is None:
         parser.error("An Ambari server must be specified " \

--- a/yaas/__main__.py
+++ b/yaas/__main__.py
@@ -23,7 +23,9 @@ def version(parser, args):
     print(YAAS_VERSION)
 
 def main():
-    config.server_url = os.environ.get('YAAS_SERVER_URL', config.server_url)
+    config.scheme = os.environ.get('YAAS_SCHEME', config.scheme)
+    config.server = os.environ.get('YAAS_SERVER', config.server)
+    config.port = os.environ.get('YAAS_PORT', config.port)
     config.username = os.environ.get('YAAS_USER', config.username)
     config.password = os.environ.get('YAAS_PASSWORD', config.password)
 
@@ -60,9 +62,9 @@ def main():
     args, extra = parser.parse_known_args(sys.argv[1:])
     config.args = args
 
-    if args.command != 'version' and config.server_url is None:
-        parser.error("Ambari server URL must be specified " \
-            "through environment variable YAAS_SERVER_URL")
+    if args.command != 'version' and config.server is None:
+        parser.error("An Ambari server must be specified " \
+            "through environment variable YAAS_SERVER.")
 
     commands[args.command](subparsers.choices[args.command], extra)
 

--- a/yaas/config.py
+++ b/yaas/config.py
@@ -6,7 +6,9 @@ from __future__ import print_function
 # These default configs are overriden based on
 # command line arguments or environment variables
 
-server_url = None   # Must be overriden
+scheme = 'http'
+server = None   # Must be overriden
+port = 8080
 username = 'admin'
 password = 'admin'
 args = None

--- a/yaas/config.py
+++ b/yaas/config.py
@@ -3,30 +3,34 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import pprint
+import requests
+
 # These default configs are overriden based on
-# command line arguments or environment variables
+# command line arguments or environment variables.
 
 scheme = 'http'
 server = None   # Must be overriden
 port = 8080
 username = 'admin'
 password = 'admin'
-args = None
+command = None
 
-def print_request_and_response(res, *args, **kwargs):
-    print("Request:", res.request.__dict__)
-    print("Response:", res.__dict__)
 
-def requests_opts():
-    opts = {
-        'auth': (username, password),
-        'headers': {'X-Requested-By': 'Ambari'},
-        }
-
-    if args.verbose:
-        opts['hooks'] = {
-            'response': print_request_and_response,
-            }
-
-    return opts
-
+def request(endpoint):
+    def decorator(fn):
+        def wrapper(*args, **kwargs):
+            r = requests.get(
+                '{scheme}://{server}:{port}{path}'.format(
+                    scheme=scheme,
+                    server=server,
+                    port=port,
+                    path=endpoint),
+                auth=(username, password),
+                headers={'X-Requested-By': 'Ambari'})
+            if command.verbose:
+                pprint.pprint(r.json())
+            else:
+                fn(*args, response=r, **kwargs)
+        return wrapper
+    return decorator

--- a/yaas/host.py
+++ b/yaas/host.py
@@ -1,4 +1,29 @@
 # coding: utf-8
 
+from __future__ import absolute_import
+from __future__ import print_function
+
+import inspect
+
+from . import config
+
+
 def command(parser, args):
-    pass
+    """ Interact with server agents. """
+    subparsers = parser.add_subparsers(dest='subcommand')
+    subcommands = {
+        'list': host_list
+        }
+    for name, fn in subcommands.items():
+        subparsers.add_parser(name, help=inspect.getdoc(fn))
+    subargs, extra = parser.parse_known_args(args)
+    subcommands[subargs.subcommand](
+        subparsers.choices[subargs.subcommand],
+        extra)
+
+
+@config.request('/api/v1/hosts')
+def host_list(parser, args, response):
+    """ List all server agents. """
+    for item in response.json()['items']:
+        print(item['Hosts']['host_name'])


### PR DESCRIPTION
This will happen if a path is specified in `YAAS_SERVER_URL`:

```
$ env YAAS_SERVER_URL=http://localhost:8080/ python -m yaas host list
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/david/projects/yaas/yaas/__main__.py", line 70, in <module>
    main()
  File "/Users/david/projects/yaas/yaas/__main__.py", line 67, in main
    commands[args.command](subparsers.choices[args.command], extra)
  File "yaas/host.py", line 22, in command
    subparsers.choices[subargs.subcommand], extra
  File "yaas/host.py", line 34, in host_list
    for item in r.json()['items']:
KeyError: 'items'
```

It happens because `http://localhost:8080//api/v1/...` returns a 404.
