### PR TITLE
Revise env vars.

### DIFF
--- a/yaas/__main__.py
+++ b/yaas/__main__.py
@@ -23,7 +23,9 @@ def version(parser, args):
     print(YAAS_VERSION)
 
 def main():
-    config.server_url = os.environ.get('YAAS_SERVER_URL', config.server_url)
+    config.scheme = os.environ.get('YAAS_SCHEME', config.scheme)
+    config.server = os.environ.get('YAAS_SERVER', config.server)
+    config.port = os.environ.get('YAAS_PORT', config.port)
     config.username = os.environ.get('YAAS_USER', config.username)
     config.password = os.environ.get('YAAS_PASSWORD', config.password)
 
@@ -60,9 +62,9 @@ def main():
     args, extra = parser.parse_known_args(sys.argv[1:])
     config.args = args
 
-    if args.command != 'version' and config.server_url is None:
-        parser.error("Ambari server URL must be specified " \
-            "through environment variable YAAS_SERVER_URL")
+    if args.command != 'version' and config.server is None:
+        parser.error("An Ambari server must be specified " \
+            "through environment variable YAAS_SERVER.")
 
     commands[args.command](subparsers.choices[args.command], extra)
 

--- a/yaas/__main__.py
+++ b/yaas/__main__.py
@@ -18,9 +18,11 @@ from . import task
 
 YAAS_VERSION = "yaas version {0}".format(__version__)
 
+
 def version(parser, args):
     """print the yaas version"""
     print(YAAS_VERSION)
+
 
 def main():
     config.scheme = os.environ.get('YAAS_SCHEME', config.scheme)
@@ -61,10 +63,6 @@ def main():
 
     args, extra = parser.parse_known_args(sys.argv[1:])
     config.args = args
-
-    if args.command != 'version' and config.server is None:
-        parser.error("An Ambari server must be specified " \
-            "through environment variable YAAS_SERVER.")
 
     commands[args.command](subparsers.choices[args.command], extra)
 

--- a/yaas/config.py
+++ b/yaas/config.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 # command line arguments or environment variables
 
 scheme = 'http'
-server = None   # Must be overriden
+server = 'localhost'
 port = 8080
 username = 'admin'
 password = 'admin'

--- a/yaas/config.py
+++ b/yaas/config.py
@@ -6,7 +6,9 @@ from __future__ import print_function
 # These default configs are overriden based on
 # command line arguments or environment variables
 
-server_url = None   # Must be overriden
+scheme = 'http'
+server = None   # Must be overriden
+port = 8080
 username = 'admin'
 password = 'admin'
 args = None

--- a/yaas/config.py
+++ b/yaas/config.py
@@ -3,9 +3,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-# These default configs are overriden based on
-# command line arguments or environment variables
-
+# These default configs are overriden by environment variables
 scheme = 'http'
 server = 'localhost'
 port = 8080


### PR DESCRIPTION
I've switched YAAS_SERVER_URL to YAAS_SCHEMA, YAAS_SERVER, and YAAS_PORT for a few reasons.
1. We can set reasonable defaults for schema and port.
2. A proper URL (like the example above) includes a path (/); however, it is yaas's job to specify the appropriate path (/api/v1/...). If both do it, we get something like http://ambari.server:8080//api/v1/... which returns a 404.
3. If we want to be smart about handling 2, we would probably end up parsing out schema, server, and port and storing them separately anyways. If they are split from the beginning, we can save the user some typing and the developer some parsing... win-win.

Also, I'm removing automatic printing from the requests hook. We have to check if verbose mode is set anyways to avoid printing non-verbose (read: redundant) output. Instead, we ought to use a `git branch -v`-like paradigm which more closely aligns with only printing the JSON response in verbose mode. (Perhaps we add a `-vv` or `--debug` option down the road to show the full request and response.)
